### PR TITLE
chore: bump to 0.2.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@presencekit/core",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@presencekit/react",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -13,7 +13,7 @@
     }
   },
   "peerDependencies": {
-    "@presencekit/core": "^0.1.0",
+    "@presencekit/core": "^0.2.0",
     "react": ">=17",
     "react-dom": ">=17"
   },


### PR DESCRIPTION
- Add types condition to exports for proper TypeScript resolution
- Add sideEffects: false for better tree-shaking
- Fix show:[] filter to return empty list instead of all links
- Fix group-popover accessibility: change role="dialog" to role="menu"
- Add Escape key and keyboard dismiss support for popovers
- Remove redundant --passWithNoTests flag